### PR TITLE
Fix urllib2 import in slim_walkthrough notebook

### DIFF
--- a/slim/slim_walkthrough.ipynb
+++ b/slim/slim_walkthrough.ipynb
@@ -818,7 +818,7 @@
     "import tensorflow as tf\n",
     "\n",
     "try:\n",
-    "    import urllib2\n",
+    "    import urllib2 as urllib\n",
     "except ImportError:\n",
     "    import urllib.request as urllib\n",
     "\n",


### PR DESCRIPTION
Adding 10 characters to make cell [28] run without error